### PR TITLE
Fix for column names in raw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ jspm_packages
 # Optional REPL history
 .node_repl_history
 .vscode/*
+.idea

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function addCondition (q, field, val) {
       return val.forEach(addCondition.bind(null, this, field));
     });
   }
-  
+
   if (!Array.isArray(val)) {
     // Simple string or number value
     val = ['AND', field, val ];
@@ -78,7 +78,7 @@ function addCondition (q, field, val) {
       }
     }
   }
-  var args = val[0].includes('RAW') ? [ '"'+val[1]+'" ' + val[2] ] : val.slice(1)
+  var args = val[0].includes('RAW') ? [ q.client.raw('??', val[1]) + ' ' + val[2] ] : val.slice(1);
   return q[functionOperatorMap[val[0]]].apply(q, args);
 }
 


### PR DESCRIPTION
Use raw method to wrap column names with ticks when uses raw operator

This solve issues when tries compare two columns in a query like:

  ```
  const knex = require('knex')({ client: 'mysql' });

  const tableName = 'metrics';
  const query = {};
  query.use_count = { $raw: '< `use_limit`' };
  
  const statement = knex(this.tableName)
        .where(jsonQuery(query))
        .toString();
```
that results in 
```
WHERE "use_count" < `use_limit`
```

but should be 
```
 WHERE `use_count` < `use_limit`
```